### PR TITLE
Update LONG_PUSHED time

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -187,7 +187,7 @@ public:
                 timer.start();
             } else if (now == 0) {
                 auto elapsed{timer.elapsed_time()};
-                if (elapsed > 10s) {
+                if (elapsed > 60s) {
                     if (state != STATE::LONG_PUSHED)
                         state = STATE::LONG_PUSHED;
                 } else if (elapsed > 3s) {


### PR DESCRIPTION
close #4 

強制終了時間( long push判定時間 )を10sから60sに更新しています。
slackでご教示いただいた通りの修正です。