### PR TITLE
Fixed the always return true for temperature is_ok() if no sensor is installed

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -542,17 +542,17 @@ public:
         if (i2c.write(ADDR, reinterpret_cast<const char*>(buf), 1, true) == 0 &&
             i2c.read(ADDR, reinterpret_cast<char*>(buf), 1) == 0 &&
             (buf[0] & 0b11111000) == 0b11001000) {
-            isInstalled = true; //As ID was read successfully we assume that is installed
+            successfullyDetected = true; // As ID was read successfully we assume that is installed
             buf[0] = 0x03; // Configuration Register
             buf[1] = 0b10000000; // 16bit
             i2c.write(ADDR, reinterpret_cast<const char*>(buf), 2);
         }
     }
     bool is_ok() const {
-        if(isInstalled)
-          return temperature < 80.0f;
+        if (successfullyDetected)
+            return temperature < 80.0f;
         else
-          return false; //Avoid returning true if sensor is not installed
+            return false; // Avoid returning true if sensor is not detected
     }
     int get_temperature() const {
         if (temperature > 127.0f)
@@ -576,7 +576,7 @@ public:
     }
 private:
     float temperature{0.0f};
-    bool isInstalled;
+    bool successfullyDetected{false}; // Default false until sensor was detected
     static constexpr int ADDR{0b10010000};
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -542,13 +542,17 @@ public:
         if (i2c.write(ADDR, reinterpret_cast<const char*>(buf), 1, true) == 0 &&
             i2c.read(ADDR, reinterpret_cast<char*>(buf), 1) == 0 &&
             (buf[0] & 0b11111000) == 0b11001000) {
+            isInstalled = true; //As ID was read successfully we assume that is installed
             buf[0] = 0x03; // Configuration Register
             buf[1] = 0b10000000; // 16bit
             i2c.write(ADDR, reinterpret_cast<const char*>(buf), 2);
         }
     }
     bool is_ok() const {
-        return temperature < 80.0f;
+        if(isInstalled)
+          return temperature < 80.0f;
+        else
+          return false; //Avoid returning true if sensor is not installed
     }
     int get_temperature() const {
         if (temperature > 127.0f)
@@ -572,6 +576,7 @@ public:
     }
 private:
     float temperature{0.0f};
+    bool isInstalled;
     static constexpr int ADDR{0b10010000};
 };
 


### PR DESCRIPTION
Stumbled upon this and checked the issues.
Looking at the code it looks like you are using the ADT7410 by Analog Devices or a derivative.

This pull request should prevent the "always return true" if no sensor is installed.

It checks if the sensor is installed while checking the ID register. In case this is wrong it is assumed that there is no sensor installed -> returns false.