### PR TITLE
Feature/us charger

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -486,9 +486,9 @@ private: // Thermistor side starts here.
     void send_heartbeat() {                                                    /* Creates the message to send to the robot using the "compose" function below */
         uint8_t sw_state{0};
 
-        if(is_connected()){
+        if (is_connected()) {
             sw_state = 1;
-        }else{
+        } else {
             sw_state = 0;
         }
          
@@ -899,7 +899,7 @@ private:
                 LOG("plugged to manual charger\n");
                 set_new_state(POWER_STATE::MANUAL_CHARGE);
             } else if (!charge_guard_asserted && ac.is_docked() && bmu.is_chargable()) {
-                if(ac.is_charger_ready() == true){
+                if (ac.is_charger_ready() == true) {
                     LOG("docked to auto charger\n");
                     set_new_state(POWER_STATE::AUTO_CHARGE);
                 }

--- a/main.cpp
+++ b/main.cpp
@@ -400,10 +400,10 @@ public:
         send_heartbeat();
     }
     bool is_charger_ready() const {
-        if(connector_v > (CHARGING_VOLTAGE * 0.9)){
+        if (connector_v > (CHARGING_VOLTAGE * 0.9)) {
             LOG("charger ready voltage:%f.\n", connector_v);
             return true;
-        }else {
+        } else {
             LOG("connector_v:%f THRESH:%f\n", connector_v, (CHARGING_VOLTAGE * 0.9));
             return false;
         }

--- a/main.cpp
+++ b/main.cpp
@@ -1084,7 +1084,7 @@ private:
         watchdog.kick();
     }
     void poll_10s() {
-        uint8_t buf[8]{'2', '0', '3'}; // version
+        uint8_t buf[8]{'2', '1', '3'}; // version
         can.send(CANMessage{0x203, buf});
     }
     can_driver can;

--- a/main.cpp
+++ b/main.cpp
@@ -391,7 +391,6 @@ public:
     }
     bool is_docked() const {
         return is_connected() && !temperature_error && !is_overheat() && heartbeat_timer.elapsed_time() < 5s;
-        // return is_charger_ready() && is_connected() && !temperature_error && !is_overheat() && heartbeat_timer.elapsed_time() < 5s;
     }
     void set_enable(bool enable) {
         sw.write(enable ? 1 : 0);
@@ -904,8 +903,6 @@ private:
                     LOG("docked to auto charger\n");
                     set_new_state(POWER_STATE::AUTO_CHARGE);
                 }
-                // LOG("docked to auto charger\n");
-                // set_new_state(POWER_STATE::AUTO_CHARGE);
             }
             break;
         case POWER_STATE::AUTO_CHARGE:


### PR DESCRIPTION
FastChargeではベースとしている充電器の違いから、従来シーケンスのAMR側SSRオン→Charger側SSRオンとすると、AMR側SSRがオンした瞬間にCharget側SSRのダイオードを経由してAMR側から電流が流れてしまい、BMUが過電流を検出してAMRが落ちてしまう。その対策として、Charger側SSRをONした後に、AMR側SSRをONする。これによりCharger側の電位が高い状態でAMR側SSRがオンするので、AMR側から電流が流れることを防止できる。

対策として
- 充電器を検出（5Vを検出）したらCharger側のSSRをON
- 自動充電電極で充電電圧の90%以上が検出されたならば、Charger側の準備ができたとして、AMR側のSSRをONにする

としている。この対策は、FastChargeでも従来の充電器でもどちらにAMRが充電しにいっても問題なく動作する。

Due to the difference in the chargers on which FastCharge is based, if the conventional sequence is AMR side SSR on -> Charger side SSR on, current flows from the AMR side via the diode in the Charget side SSR the moment the AMR side SSR turns on, and the BMU detects the overcurrent and The BMU detects the overcurrent and the AMR falls down. As a countermeasure, turn on the AMR-side SSR after turning on the Charger-side SSR. This turns on the AMR-side SSR while the Charger-side potential is high, thus preventing current from flowing from the AMR side.

Countermeasures
- Turn on the Charger side SSR when the charger is detected (5V is detected)
- If 90% or more of the charging voltage is detected at the automatic charging electrode, then turn on the SSR on the AMR side as the Charger side is ready

This measure works fine whether AMR goes to FastCharge or a conventional charger to charge the battery.