### PR TITLE
[AMRAP-578] fix timer overflow

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -318,7 +318,7 @@ private:
     bool left_asserted{false}, right_asserted{false};
     Timer left_timer, right_timer;
     static constexpr uint32_t COUNT{5};
-    static constexpr uint16_t DELAY_TIME_MS{500};
+    static constexpr uint32_t DELAY_TIME_MS{500};
 };
 
 class wheel_switch { // Variables Implemented
@@ -491,7 +491,7 @@ private: // Thermistor side starts here.
         } else {
             sw_state = 0;
         }
-         
+
         uint8_t buf[8], param[3]{++heartbeat_counter, sw_state, rsoc}; // Message composed of 8 bytes, 3 bytes parameters -- Declaration
         serial_message::compose(buf, serial_message::HEARTBEAT, param);
 #ifndef SERIAL_DEBUG
@@ -747,7 +747,7 @@ private:
     Timer heartbeat_timer, delay_timer;
     bool heartbeat_timeout{true}, heartbeat_detect{false}, ros_heartbeat_timeout{false}, emergency_stop{true}, power_off{false},
          mainboard_overheat{false}, actuatorboard_overheat{false}, wheel_poweroff{false};
-    static constexpr uint16_t DELAY_TIME_MS{500};
+    static constexpr uint32_t DELAY_TIME_MS{500};
 };
 
 class state_controller { // Variables Implemented
@@ -1124,7 +1124,7 @@ private:
         watchdog.kick();
     }
     void poll_10s() {
-        uint8_t buf[8]{'2', '2', '0'}; // version
+        uint8_t buf[8]{'2', '2', '1'}; // version
         can.send(CANMessage{0x203, buf});
     }
     can_driver can;


### PR DESCRIPTION
2バイトの整数型のため、0.5sをマイクロ秒で表現しようとするとオーバーフローしてしまい、意図した時間とならない。
また、今後より長い時間にする可能性もある。
よって、型を変更する。

Because of the 2-byte integer type, trying to express 0.5s in microseconds will result in an overflow and not the intended time.
There is also a possibility that a longer time may be used in the future.
Therefore, the type is changed.

