### PR TITLE
[IOP-980] update softbrake time

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1124,7 +1124,7 @@ private:
         watchdog.kick();
     }
     void poll_10s() {
-        uint8_t buf[8]{'2', '2', '1'}; // version
+        uint8_t buf[8]{'2', '2', '2'}; // version
         can.send(CANMessage{0x203, buf});
     }
     can_driver can;

--- a/main.cpp
+++ b/main.cpp
@@ -318,7 +318,7 @@ private:
     bool left_asserted{false}, right_asserted{false};
     Timer left_timer, right_timer;
     static constexpr uint32_t COUNT{5};
-    static constexpr uint32_t DELAY_TIME_MS{500};
+    static constexpr uint32_t DELAY_TIME_MS{2000};
 };
 
 class wheel_switch { // Variables Implemented
@@ -747,7 +747,7 @@ private:
     Timer heartbeat_timer, delay_timer;
     bool heartbeat_timeout{true}, heartbeat_detect{false}, ros_heartbeat_timeout{false}, emergency_stop{true}, power_off{false},
          mainboard_overheat{false}, actuatorboard_overheat{false}, wheel_poweroff{false};
-    static constexpr uint32_t DELAY_TIME_MS{500};
+    static constexpr uint32_t DELAY_TIME_MS{2000};
 };
 
 class state_controller { // Variables Implemented


### PR DESCRIPTION
Release as v2.2.2 with a softbrake time of 2 seconds.

softbrakeの時間を2秒にしてv2.2.2としてリリースする。